### PR TITLE
Fix curly braces in rendered HTML

### DIFF
--- a/src/twigextensions/ResponsiveImagesTwigExtension.php
+++ b/src/twigextensions/ResponsiveImagesTwigExtension.php
@@ -120,7 +120,7 @@ class ResponsiveImagesTwigExtension extends \Twig_Extension
             }
         }
 
-        $newHTML = preg_replace('~<(?:!DOCTYPE|/?(?:html|head|body))[^>]*>\s*~i', '', $document->saveHTML());
+        $newHTML = str_replace(array('%7B','%7D'), array('{','}'), $document->saveHTML( $document->documentElement ));
 
         if ($isRedactor) {
             return new craft\redactor\FieldData($newHTML);


### PR DESCRIPTION
Also used `$document->documentElement` so you don't need a regex to remove the doctype declaration.